### PR TITLE
� Fix GitHub Pages URL mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Phaser](https://img.shields.io/badge/Phaser-3.80.1-orange.svg)
 ![Node](https://img.shields.io/badge/Node.js-18+-green.svg)
 
-## 🎮 [**PLAY GAME NOW!**](https://torresjdev.github.io/Phaser-Game/) 🚀
+## 🎮 [**PLAY GAME NOW!**](https://torresjdev.github.io/JS-Phaser-Game-Jumper/) 🚀
 
 ![Game Logo](/public/assets/images/ui/game-logo.png)
 
@@ -51,7 +51,7 @@ Welcome to **Jumper**, an exciting platformer game where you control a nimble ch
 
 ## 🌐 Live Demo & Deployment
 
-🎮 **Play Online**: [https://torresjdev.github.io/Phaser-Game/](https://torresjdev.github.io/Phaser-Game/)
+🎮 **Play Online**: [https://torresjdev.github.io/JS-Phaser-Game-Jumper/](https://torresjdev.github.io/JS-Phaser-Game-Jumper/)
 
 ### Deployment Status
 

--- a/webpack/config.prod.js
+++ b/webpack/config.prod.js
@@ -15,7 +15,7 @@ module.exports = {
 	output: {
 		path: path.resolve(process.cwd(), "dist"),
 		filename: "./bundle.min.js",
-		publicPath: "/Phaser-Game/",
+		publicPath: "/JS-Phaser-Game-Jumper/",
 	},
 	devtool: false,
 	performance: {


### PR DESCRIPTION
✅ Updated webpack publicPath:
- Changed from '/Phaser-Game/' to '/JS-Phaser-Game-Jumper/'
- Matches actual GitHub Pages URL structure

✅ Updated README URLs:
- Play button now points to correct URL
- Live demo section updated

� Game should now load properly at:
https://torresjdev.github.io/JS-Phaser-Game-Jumper/